### PR TITLE
fix(typography): Remove leading default

### DIFF
--- a/packages/react/lib/Heading/Heading.tsx
+++ b/packages/react/lib/Heading/Heading.tsx
@@ -36,7 +36,7 @@ const Heading = React.forwardRef<HTMLHeadingElement, HeadingProps>(
       weight = "bold",
       variant = "default",
       align,
-      leading = "normal",
+      leading, // No default: Tailwind applies a default from text size classes
       tracking = "normal",
       family = "display",
       truncate = false,

--- a/packages/react/lib/Text/Text.tsx
+++ b/packages/react/lib/Text/Text.tsx
@@ -39,7 +39,7 @@ const Text = React.forwardRef(
       weight = "normal",
       variant = "default",
       align,
-      leading = "normal",
+      leading, // No default: Tailwind applies a default from text size classes
       tracking = "normal",
       family = "display",
       truncate = false,

--- a/packages/react/src/App.tsx
+++ b/packages/react/src/App.tsx
@@ -1,19 +1,7 @@
 import { Demo } from "./Demo";
 
 function App() {
-  return (
-    <div>
-      <h4 className="text-foreground font-display scroll-m-20 text-xl font-bold tracking-normal">
-        User Profile
-      </h4>
-      <h4 className="text-foreground font-display scroll-m-20 text-xl leading-none font-bold tracking-normal">
-        User Profile
-      </h4>
-      <h4 className="text-foreground font-display scroll-m-20 text-xl leading-normal font-bold tracking-normal">
-        User Profile
-      </h4>
-    </div>
-  );
+  return <Demo />;
 }
 
 export default App;

--- a/packages/react/src/App.tsx
+++ b/packages/react/src/App.tsx
@@ -1,7 +1,19 @@
 import { Demo } from "./Demo";
 
 function App() {
-  return <Demo />;
+  return (
+    <div>
+      <h4 className="text-foreground font-display scroll-m-20 text-xl font-bold tracking-normal">
+        User Profile
+      </h4>
+      <h4 className="text-foreground font-display scroll-m-20 text-xl leading-none font-bold tracking-normal">
+        User Profile
+      </h4>
+      <h4 className="text-foreground font-display scroll-m-20 text-xl leading-normal font-bold tracking-normal">
+        User Profile
+      </h4>
+    </div>
+  );
 }
 
 export default App;

--- a/packages/react/stories/Heading.stories.tsx
+++ b/packages/react/stories/Heading.stories.tsx
@@ -248,8 +248,11 @@ export const Variants: Story = {
 export const Leading: Story = {
   render: () => (
     <OptionList<TextLeading>
-      options={TEXT_LEADINGS as unknown as TextLeading[]}
+      options={[undefined, ...TEXT_LEADINGS] as unknown as TextLeading[]}
       gapY="0"
+      renderRowTitle={(option) => (
+        <Text>{option === undefined ? "<no value>" : option}</Text>
+      )}
       renderOption={(leading: TextLeading) => (
         <>
           <Heading leading={leading}>{sampleHeading}</Heading>

--- a/packages/react/stories/Text.stories.tsx
+++ b/packages/react/stories/Text.stories.tsx
@@ -257,7 +257,10 @@ export const Alignments: Story = {
 export const Leading: Story = {
   render: () => (
     <OptionList<TextLeading>
-      options={TEXT_LEADINGS as unknown as TextLeading[]}
+      options={[undefined, ...TEXT_LEADINGS] as unknown as TextLeading[]}
+      renderRowTitle={(option) => (
+        <Text>{option === undefined ? "<no value>" : option}</Text>
+      )}
       renderOption={(leading: TextLeading) => (
         <Text leading={leading} size="sm">
           {sampleLongText[1]}

--- a/packages/react/tests/Heading.test.tsx
+++ b/packages/react/tests/Heading.test.tsx
@@ -9,13 +9,10 @@ describe("Heading", () => {
     render(<Heading>Hello world</Heading>);
     const element = screen.getByText("Hello world");
 
-    expect(element.tagName).toBe("H2"); // Default level is 2
-    expect(element).toHaveClass("text-3xl"); // Default size for h2
-    expect(element).toHaveClass("font-bold"); // Default weight
-    expect(element).toHaveClass("text-foreground"); // Default variant
-    expect(element).toHaveClass("tracking-normal"); // Default tracking
-    expect(element).toHaveClass("font-display"); // Default family
-    expect(element).toHaveClass("scroll-m-20"); // Should have scroll margin
+    expect(element.tagName).toBe("H2");
+    expect(element.className).toBe(
+      "text-3xl font-bold text-foreground tracking-normal font-display scroll-m-20"
+    );
   });
 
   it("renders headings with different levels", () => {

--- a/packages/react/tests/Text.test.tsx
+++ b/packages/react/tests/Text.test.tsx
@@ -10,11 +10,9 @@ describe("Text", () => {
     const element = screen.getByText("Hello world");
 
     expect(element.tagName).toBe("P");
-    expect(element).toHaveClass("text-base");
-    expect(element).toHaveClass("font-normal");
-    expect(element).toHaveClass("text-foreground"); // Default variant
-    expect(element).toHaveClass("leading-normal");
-    expect(element).toHaveClass("font-display");
+    expect(element.className).toBe(
+      "text-base font-normal text-foreground tracking-normal font-display"
+    );
   });
 
   it("renders with custom element type", () => {


### PR DESCRIPTION
Added in https://github.com/jszymanowski/breeze/pull/44 -- it turns out `normal` is not the default Tailwind style.  Rather, Tailwind applies default line-height (leading) styles based on the text-size.