### PR TITLE
chore(ci): Use dryRun to prevent publishing on PRs

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -46,7 +46,5 @@ jobs:
           buildScriptName: "storybook:build"
           exitOnceUploaded: true
           onlyChanged: true
-          # For main branch: Auto-accept changes and publish
+          dryRun: ${{ github.event_name == 'pull_request' && true || false }}
           autoAcceptChanges: "main"
-          # For PRs: Only check for changes without publishing or auto-accepting
-          storybookBuildDir: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && './packages/react/storybook-static' || '' }}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -46,5 +46,5 @@ jobs:
           buildScriptName: "storybook:build"
           exitOnceUploaded: true
           onlyChanged: true
-          dryRun: ${{ github.event_name == 'pull_request' && true || false }}
+          dryRun: ${{ github.event_name == 'pull_request' }}
           autoAcceptChanges: "main"


### PR DESCRIPTION
https://github.com/jszymanowski/breeze/pull/92 did not work; dryRun seems to be the proper way to achieve this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Enhanced the automated preview process to now simulate builds for pull request events, ensuring safer testing.
	- Streamlined the configuration by removing an unnecessary parameter, optimizing the build pipeline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->