### PR TITLE
tweak: Remove redundant default typography styles

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,6 +13,7 @@ Follow [Conventional Commits](https://www.conventionalcommits.org/) specificatio
 ### Patch version `_._.N` 
 - `fix:` A bug fix
 - `perf:` Performance improvements
+- `tweak:` Minor change with no obivous end-user changes
 - `revert:` Revert a previous commit
 
 ### Minor version `_.N.0` 

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Validate PR Title
         run: |
           PR_TITLE="${{ github.event.pull_request.title }}"
-          if ! echo "$PR_TITLE" | grep -E '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?!?: [A-Z].+$'; then
+          if ! echo "$PR_TITLE" | grep -E '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert|tweak)(\(.+\))?!?: [A-Z].+$'; then
             echo "PR title '$PR_TITLE' does not follow conventional commit format"
             exit 1
           fi

--- a/packages/react/docs/ROADMAP.md
+++ b/packages/react/docs/ROADMAP.md
@@ -5,13 +5,9 @@
 ### Upcoming (pre-1.0.0)
 
 1. Clean up stories:
-   - [ ] Refactor example displays, e.g. background color + border, particularly in `Box` stories
+   - [ ] Refactor example structure, e.g. background color + border, particularly in `Box` stories
    - [ ] `Box` examples => Composition, merge with attribute stories, or remove
    - [ ] Use defined attributes in Composition examples
-1. Reconsider defaults
-   - [ ] `Text`
-   - [ ] `Heading`
-   - [x] layouts
 1. Write documentation
 
 ### Later (post-1.0.0)

--- a/packages/react/lib/Heading/Heading.tsx
+++ b/packages/react/lib/Heading/Heading.tsx
@@ -31,13 +31,13 @@ const Heading = React.forwardRef<HTMLHeadingElement, HeadingProps>(
   (
     {
       className,
+      variant = "default",
       level = "2",
       size,
-      weight = "bold",
-      variant = "default",
+      weight = "bold", // Typical default browser style for headings
       align,
       leading, // No default: Tailwind applies a default from text size classes
-      tracking = "normal",
+      tracking,
       family = "display",
       truncate = false,
       numeric = false,

--- a/packages/react/lib/Text/Text.tsx
+++ b/packages/react/lib/Text/Text.tsx
@@ -35,12 +35,12 @@ const Text = React.forwardRef(
     {
       className,
       as,
-      size = "base",
-      weight = "normal",
+      size,
+      weight,
       variant = "default",
       align,
       leading, // No default: Tailwind applies a default from text size classes
-      tracking = "normal",
+      tracking,
       family = "display",
       truncate = false,
       numeric = false,

--- a/packages/react/tests/Heading.test.tsx
+++ b/packages/react/tests/Heading.test.tsx
@@ -22,7 +22,7 @@ describe("Heading", () => {
 
     expect(element.tagName).toBe("H2");
     expect(element.className).toBe(
-      "text-3xl font-bold text-foreground tracking-normal font-display scroll-m-20",
+      "text-3xl font-bold text-foreground font-display scroll-m-20",
     );
   });
 
@@ -41,7 +41,7 @@ describe("Heading", () => {
       const element = screen.getByText(`Heading ${level}`);
       expect(element.tagName).toBe(`H${level}`);
       expect(element.className).toBe(
-        `${levelSizeMap[level]} font-bold text-foreground tracking-normal font-display scroll-m-20`,
+        `${levelSizeMap[level]} font-bold text-foreground font-display scroll-m-20`,
       );
     }
   });
@@ -57,7 +57,7 @@ describe("Heading", () => {
 
       const expectedCssClass = size === "md" ? "text-base" : `text-${size}`;
       expect(element.className).toBe(
-        `${expectedCssClass} font-bold text-foreground tracking-normal font-display scroll-m-20`,
+        `${expectedCssClass} font-bold text-foreground font-display scroll-m-20`,
       );
     }
   });
@@ -67,14 +67,18 @@ describe("Heading", () => {
       render(<Heading weight={weight as FontWeight}>Weight {weight}</Heading>);
       const element = screen.getByText(`Weight ${weight}`);
       expect(element.className).toBe(
-        `text-3xl font-${weight} text-foreground tracking-normal font-display scroll-m-20`,
+        `text-3xl font-${weight} text-foreground font-display scroll-m-20`,
       );
     }
   });
 
   it("applies the correct variant classes", () => {
     for (const variant of TYPOGRAPHY_VARIANTS) {
-      render(<Heading variant={variant as TypographyVariant}>Variant {variant}</Heading>);
+      render(
+        <Heading variant={variant as TypographyVariant}>
+          Variant {variant}
+        </Heading>,
+      );
       const element = screen.getByText(`Variant ${variant}`);
 
       let expectedCssClass = "";
@@ -87,7 +91,7 @@ describe("Heading", () => {
       }
 
       expect(element.className).toBe(
-        `text-3xl font-bold ${expectedCssClass} tracking-normal font-display scroll-m-20`,
+        `text-3xl font-bold ${expectedCssClass} font-display scroll-m-20`,
       );
     }
   });
@@ -97,7 +101,7 @@ describe("Heading", () => {
       render(<Heading align={align}>Align {align}</Heading>);
       const element = screen.getByText(`Align ${align}`);
       expect(element.className).toBe(
-        `text-3xl font-bold text-foreground text-${align} tracking-normal font-display scroll-m-20`,
+        `text-3xl font-bold text-foreground text-${align} font-display scroll-m-20`,
       );
     }
   });
@@ -117,7 +121,7 @@ describe("Heading", () => {
       render(<Heading leading={leading}>Leading {leading}</Heading>);
       const element = screen.getByText(`Leading ${leading}`);
       expect(element.className).toBe(
-        `text-3xl font-bold text-foreground leading-${leading} tracking-normal font-display scroll-m-20`,
+        `text-3xl font-bold text-foreground leading-${leading} font-display scroll-m-20`,
       );
     }
   });
@@ -127,7 +131,7 @@ describe("Heading", () => {
       render(<Heading family={family}>Family {family}</Heading>);
       const element = screen.getByText(`Family ${family}`);
       expect(element.className).toBe(
-        `text-3xl font-bold text-foreground tracking-normal font-${family} scroll-m-20`,
+        `text-3xl font-bold text-foreground font-${family} scroll-m-20`,
       );
     }
   });
@@ -136,7 +140,7 @@ describe("Heading", () => {
     render(<Heading numeric>123456</Heading>);
     const element = screen.getByText("123456");
     expect(element.className).toBe(
-      "text-3xl font-bold text-foreground tracking-normal font-display tabular-nums scroll-m-20",
+      "text-3xl font-bold text-foreground font-display tabular-nums scroll-m-20",
     );
   });
 
@@ -155,7 +159,7 @@ describe("Heading", () => {
     render(<Heading className="custom-class">With custom class</Heading>);
     const element = screen.getByText("With custom class");
     expect(element.className).toBe(
-      "text-3xl font-bold text-foreground tracking-normal font-display scroll-m-20 custom-class",
+      "text-3xl font-bold text-foreground font-display scroll-m-20 custom-class",
     );
   });
 
@@ -171,7 +175,7 @@ describe("Heading", () => {
     render(<Heading>Heading with scroll margin</Heading>);
     const element = screen.getByText("Heading with scroll margin");
     expect(element.className).toBe(
-      "text-3xl font-bold text-foreground tracking-normal font-display scroll-m-20",
+      "text-3xl font-bold text-foreground font-display scroll-m-20",
     );
   });
 

--- a/packages/react/tests/Text.test.tsx
+++ b/packages/react/tests/Text.test.tsx
@@ -18,9 +18,7 @@ describe("Text", () => {
     const element = screen.getByText("Hello world");
 
     expect(element.tagName).toBe("P");
-    expect(element.className).toBe(
-      "text-base font-normal text-foreground tracking-normal font-display",
-    );
+    expect(element.className).toBe("text-foreground font-display");
   });
 
   it("renders with custom element type", () => {
@@ -46,7 +44,7 @@ describe("Text", () => {
 
       const expectedCssClass = size === "md" ? "text-base" : `text-${size}`;
       expect(element.className).toBe(
-        `${expectedCssClass} font-normal text-foreground tracking-normal font-display`,
+        `${expectedCssClass} text-foreground font-display`,
       );
     }
   });
@@ -56,7 +54,7 @@ describe("Text", () => {
       render(<Text weight={weight}>Weight {weight}</Text>);
       const element = screen.getByText(`Weight ${weight}`);
       expect(element.className).toBe(
-        `text-base font-${weight} text-foreground tracking-normal font-display`,
+        `font-${weight} text-foreground font-display`,
       );
     }
   });
@@ -75,9 +73,7 @@ describe("Text", () => {
         expectedCssClass = `text-${variant}-foreground`;
       }
 
-      expect(element.className).toBe(
-        `text-base font-normal ${expectedCssClass} tracking-normal font-display`,
-      );
+      expect(element.className).toBe(`${expectedCssClass} font-display`);
     }
   });
 
@@ -86,7 +82,7 @@ describe("Text", () => {
       render(<Text align={align}>Align {align}</Text>);
       const element = screen.getByText(`Align ${align}`);
       expect(element.className).toBe(
-        `text-base font-normal text-foreground text-${align} tracking-normal font-display`,
+        `text-foreground text-${align} font-display`,
       );
     }
   });
@@ -96,7 +92,7 @@ describe("Text", () => {
       render(<Text tracking={tracking}>Tracking {tracking}</Text>);
       const element = screen.getByText(`Tracking ${tracking}`);
       expect(element.className).toBe(
-        `text-base font-normal text-foreground tracking-${tracking} font-display`,
+        `text-foreground tracking-${tracking} font-display`,
       );
     }
   });
@@ -106,7 +102,7 @@ describe("Text", () => {
       render(<Text leading={leading}>Leading {leading}</Text>);
       const element = screen.getByText(`Leading ${leading}`);
       expect(element.className).toBe(
-        `text-base font-normal text-foreground leading-${leading} tracking-normal font-display`,
+        `text-foreground leading-${leading} font-display`,
       );
     }
   });
@@ -115,18 +111,14 @@ describe("Text", () => {
     for (const family of FONT_FAMILIES) {
       render(<Text family={family}>Family {family}</Text>);
       const element = screen.getByText(`Family ${family}`);
-      expect(element.className).toBe(
-        `text-base font-normal text-foreground tracking-normal font-${family}`,
-      );
+      expect(element.className).toBe(`text-foreground font-${family}`);
     }
   });
 
   it("applies truncate class when truncate is true", () => {
     render(<Text truncate>Truncated text</Text>);
     const element = screen.getByText("Truncated text");
-    expect(element.className).toBe(
-      "text-base font-normal text-foreground tracking-normal font-display truncate",
-    );
+    expect(element.className).toBe("text-foreground font-display truncate");
   });
 
   it("does not apply truncate class when truncate is false", () => {
@@ -138,9 +130,7 @@ describe("Text", () => {
   it("applies tabular-nums class when numeric is true", () => {
     render(<Text numeric>123456</Text>);
     const element = screen.getByText("123456");
-    expect(element.className).toBe(
-      "text-base font-normal text-foreground tracking-normal font-display tabular-nums",
-    );
+    expect(element.className).toBe("text-foreground font-display tabular-nums");
   });
 
   it("does not apply tabular-nums class when numeric is false", () => {
@@ -157,9 +147,7 @@ describe("Text", () => {
   it("combines custom className with generated classes", () => {
     render(<Text className="custom-class">With custom class</Text>);
     const element = screen.getByText("With custom class");
-    expect(element.className).toBe(
-      "text-base font-normal text-foreground tracking-normal font-display custom-class",
-    );
+    expect(element.className).toBe("text-foreground font-display custom-class");
   });
 
   it("forwards ref correctly", () => {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,5 +7,12 @@
       "tagSeparator": "@"
     }
   },
-  "include-component-in-tag": true
+  "include-component-in-tag": true,
+  "changelog-sections": [
+    {
+      "type": "tweak",
+      "section": "Minor tweaks",
+      "hidden": false
+    }
+  ]
 }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
	- Updated default values for `Heading` and `Text` components, requiring explicit prop values for better rendering consistency.
- **Tests**
	- Simplified expected class names in tests for both `Heading` and `Text` components, reflecting a more concise styling approach.
- **Chores**
	- Added a new entry for "tweak" in the pull request template to categorize minor changes without obvious end-user impact.
	- Updated GitHub Actions workflow to accept "tweak" as a valid prefix for pull request titles.
	- Modified release configuration to include a new changelog section for minor tweaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->