### PR TITLE
chore(ci): Add automated publish step to ReleasePlease action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,13 +1,6 @@
-name: Publish (npm registry)
+name: Publish (manual)
 
-on:
-  push:
-    tags:
-      - "react@*"
-    paths:
-      - "packages/react/**"
-  release:
-    types: [created, published]
+on: workflow_dispatch
 
 jobs:
   build-and-publish:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,4 +1,4 @@
-name: Release (release-please)
+name: Release & publish (release-please)
 
 on:
   push:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,5 +16,39 @@ jobs:
 
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        # these if statements ensure that a publication only occurs when
+        # a new release is created:
+        if: ${{ steps.release.outputs.release_created }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18.x"
+          registry-url: "https://registry.npmjs.org"
+        if: ${{ steps.release.outputs.release_created }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 10.6.3
+        if: ${{ steps.release.outputs.release_created }}
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        if: ${{ steps.release.outputs.release_created }}
+
+      - name: Build package
+        run: pnpm build
+        if: ${{ steps.release.outputs.release_created }}
+
+      - name: Publish to npm Registry
+        run: pnpm publish --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+        if: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,41 +14,48 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
 
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+      
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+            
+  publish:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    runs-on: ubuntu-latest
+    
+    defaults:
+      run:
+        working-directory: ./packages/react
+
+    steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        # these if statements ensure that a publication only occurs when
-        # a new release is created:
-        if: ${{ steps.release.outputs.release_created }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "18.x"
           registry-url: "https://registry.npmjs.org"
-        if: ${{ steps.release.outputs.release_created }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:
           version: 10.6.3
-        if: ${{ steps.release.outputs.release_created }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-        if: ${{ steps.release.outputs.release_created }}
 
       - name: Build package
         run: pnpm build
-        if: ${{ steps.release.outputs.release_created }}
 
       - name: Publish to npm Registry
         run: pnpm publish --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-        if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
The publish step didn't get triggered by the `react@0.7.0` release for some reason -- rather than futzing with it, I'm using ReleasePlease's recommendation here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Transitioned the publishing process from an automatic, event-driven trigger to a manual activation, providing more control over when releases are published.
  - Enhanced the release workflow by adding an additional step that automatically publishes packages after a confirmed release, streamlining the overall release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->