### PR TITLE
feat: Use rich (dark) colors for typography variants, by default

### DIFF
--- a/packages/react/docs/ROADMAP.md
+++ b/packages/react/docs/ROADMAP.md
@@ -4,6 +4,7 @@
 
 ### Upcoming (pre-1.0.0)
 
+1. Decide on a path forward for `accent` -- deprecate?
 1. Clean up stories:
    - [ ] Refactor example structure, e.g. background color + border, particularly in `Box` stories
    - [ ] `Box` examples => Composition, merge with attribute stories, or remove

--- a/packages/react/lib/Heading/Heading.tsx
+++ b/packages/react/lib/Heading/Heading.tsx
@@ -20,6 +20,9 @@ export interface HeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
   leading?: TextLeading;
   tracking?: TextTracking;
   family?: FontFamily;
+  /**
+   * When true, apply *-foreground color classes for variants instead of regular color classes.
+   */
   asForeground?: boolean;
   truncate?: boolean;
   numeric?: boolean;

--- a/packages/react/lib/Heading/Heading.tsx
+++ b/packages/react/lib/Heading/Heading.tsx
@@ -20,6 +20,7 @@ export interface HeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
   leading?: TextLeading;
   tracking?: TextTracking;
   family?: FontFamily;
+  asForeground?: boolean;
   truncate?: boolean;
   numeric?: boolean;
   className?: string;
@@ -37,6 +38,7 @@ const Heading = React.forwardRef<HTMLHeadingElement, HeadingProps>(
       leading, // No default: Tailwind applies a default from text size classes
       tracking,
       family = "display",
+      asForeground = false,
       truncate = false,
       numeric = false,
       ...props
@@ -88,18 +90,26 @@ const Heading = React.forwardRef<HTMLHeadingElement, HeadingProps>(
             "font-bold": weight === "bold",
             "font-extrabold": weight === "extrabold",
             "font-black": weight === "black",
-          }, // Text colors (variants)
+          },
+          // Text colors (variants)
           {
             "text-foreground": variant === "default",
             "text-inherit": variant === "inherit",
             "text-muted-foreground": variant === "muted",
             "text-accent-foreground": variant === "accent",
+            // Action colors
             "text-primary-foreground": variant === "primary",
             "text-secondary-foreground": variant === "secondary",
-            "text-info-foreground": variant === "info",
-            "text-success-foreground": variant === "success",
-            "text-warning-foreground": variant === "warning",
-            "text-destructive-foreground": variant === "destructive",
+            // Accent colors (rich color variants)
+            "text-info": !asForeground && variant === "info",
+            "text-warning": !asForeground && variant === "warning",
+            "text-destructive": !asForeground && variant === "destructive",
+            "text-success": !asForeground && variant === "success",
+            // Accent colors (foreground variants)
+            "text-info-foreground": asForeground && variant === "info",
+            "text-warning-foreground": asForeground && variant === "warning",
+            "text-destructive-foreground": asForeground && variant === "destructive",
+            "text-success-foreground": asForeground && variant === "success",
           },
           // Text alignment
           {

--- a/packages/react/lib/Text/Text.tsx
+++ b/packages/react/lib/Text/Text.tsx
@@ -20,6 +20,9 @@ interface TextBaseProps {
   leading?: TextLeading;
   tracking?: TextTracking;
   family?: FontFamily;
+  /**
+   * When true, apply *-foreground color classes for variants instead of regular color classes.
+   */
   asForeground?: boolean;
   truncate?: boolean;
   numeric?: boolean;

--- a/packages/react/lib/Text/Text.tsx
+++ b/packages/react/lib/Text/Text.tsx
@@ -20,6 +20,7 @@ interface TextBaseProps {
   leading?: TextLeading;
   tracking?: TextTracking;
   family?: FontFamily;
+  asForeground?: boolean;
   truncate?: boolean;
   numeric?: boolean;
   className?: string;
@@ -42,6 +43,7 @@ const Text = React.forwardRef(
       leading, // No default: Tailwind applies a default from text size classes
       tracking,
       family = "display",
+      asForeground = false,
       truncate = false,
       numeric = false,
       ...props
@@ -87,12 +89,19 @@ const Text = React.forwardRef(
             "text-inherit": variant === "inherit",
             "text-muted-foreground": variant === "muted",
             "text-accent-foreground": variant === "accent",
+            // Action colors
             "text-primary-foreground": variant === "primary",
             "text-secondary-foreground": variant === "secondary",
-            "text-info-foreground": variant === "info",
-            "text-warning-foreground": variant === "warning",
-            "text-destructive-foreground": variant === "destructive",
-            "text-success-foreground": variant === "success",
+            // Accent colors (rich color variants)
+            "text-info": !asForeground && variant === "info",
+            "text-warning": !asForeground && variant === "warning",
+            "text-destructive": !asForeground && variant === "destructive",
+            "text-success": !asForeground && variant === "success",
+            // Accent colors (foreground variants)
+            "text-info-foreground": asForeground && variant === "info",
+            "text-warning-foreground": asForeground && variant === "warning",
+            "text-destructive-foreground": asForeground && variant === "destructive",
+            "text-success-foreground": asForeground && variant === "success",
           },
           // Text alignment
           {

--- a/packages/react/stories/Flex.stories.tsx
+++ b/packages/react/stories/Flex.stories.tsx
@@ -135,15 +135,9 @@ export const Default: Story = {
     className: "w-full h-full border-1 border-dashed border-gray-300",
     children: (
       <Fragment>
-        <FlexItem>
-          <Text variant="info">Item 1</Text>
-        </FlexItem>
-        <FlexItem>
-          <Text variant="info">Item 2</Text>
-        </FlexItem>
-        <FlexItem>
-          <Text variant="info">Item 3</Text>
-        </FlexItem>
+        <FlexItem>Item 1</FlexItem>
+        <FlexItem>Item 2</FlexItem>
+        <FlexItem>Item 3</FlexItem>
       </Fragment>
     ),
   },

--- a/packages/react/stories/Flex.stories.tsx
+++ b/packages/react/stories/Flex.stories.tsx
@@ -2,7 +2,7 @@ import { asOptionalValue, summarizeValues } from "@stories/utils";
 import type { Meta, StoryObj } from "@storybook/react";
 import { Fragment } from "react";
 
-import { Box, Flex, type FlexProps, Grid, Heading, Text } from "@/main";
+import { Box, Flex, type FlexProps, Grid, Heading } from "@/main";
 import {
   FLEX_ALIGNS,
   FLEX_DIRECTIONS,

--- a/packages/react/stories/Heading.stories.tsx
+++ b/packages/react/stories/Heading.stories.tsx
@@ -95,6 +95,11 @@ const meta: Meta<typeof Heading> = {
         type: { summary: summarizeValues(TEXT_TRACKINGS, true) },
       },
     },
+    asForeground: {
+      description:
+        "Use foreground (lighter) variant for accent colors (info, warning, success, destructive).  No effect on other variants.",
+      control: "boolean",
+    },
     numeric: {
       description: "If true, use tabular numbers for even spacing",
     },
@@ -235,6 +240,34 @@ export const Variants: Story = {
       renderOption={(family, option) => {
         const Component = () => (
           <Heading level="4" align="center" family={family} variant={option}>
+            {sampleHeading}
+          </Heading>
+        );
+
+        if (option === "inherit") {
+          return (
+            <Box className="text-violet-400">
+              <Component />{" "}
+              <Text variant="muted" size="xs" className="italic">
+                (container text color = violet-400)
+              </Text>
+            </Box>
+          );
+        }
+        return <Component />;
+      }}
+    />
+  ),
+};
+
+export const VariantsAsForeground: Story = {
+  render: () => (
+    <OptionsByFamilyGrid<TypographyVariant>
+      options={TYPOGRAPHY_VARIANTS as unknown as TypographyVariant[]}
+      propKey="variant"
+      renderOption={(family, option) => {
+        const Component = () => (
+          <Heading level="4" align="center" family={family} variant={option} asForeground>
             {sampleHeading}
           </Heading>
         );

--- a/packages/react/stories/Text.stories.tsx
+++ b/packages/react/stories/Text.stories.tsx
@@ -233,6 +233,33 @@ export const Variants: Story = {
   ),
 };
 
+export const VariantsAsForeground: Story = {
+  render: () => (
+    <OptionsByFamilyGrid<TypographyVariant>
+      options={TYPOGRAPHY_VARIANTS as unknown as TypographyVariant[]}
+      propKey="variant"
+      renderOption={(family, option) => {
+        const Component = () => (
+          <Text family={family} variant={option} asForeground>
+            {sampleText}
+          </Text>
+        );
+        if (option === "inherit") {
+          return (
+            <Box className="text-violet-400">
+              <Component />{" "}
+              <Text variant="muted" size="xs" className="italic">
+                (container text color = violet-400)
+              </Text>
+            </Box>
+          );
+        }
+        return <Component />;
+      }}
+    />
+  ),
+};
+
 export const Alignments: Story = {
   render: () => (
     <OptionList<TextAlign>

--- a/packages/react/stories/Text.stories.tsx
+++ b/packages/react/stories/Text.stories.tsx
@@ -89,6 +89,11 @@ const meta: Meta<typeof Text> = {
         type: { summary: summarizeValues(TEXT_TRACKINGS, true) },
       },
     },
+    asForeground: {
+      description:
+        "Use foreground (lighter) variant for accent colors (info, warning, success, destructive).  No effect on other variants.",
+      control: "boolean",
+    },
     truncate: {
       description:
         "If true, prevents text from wrapping by truncating overflowing text with an ellipsis (…) if needed",

--- a/packages/react/stories/templates/Code.tsx
+++ b/packages/react/stories/templates/Code.tsx
@@ -8,7 +8,6 @@ export default function Code({ children }: TextProps) {
       align="right"
       variant="accent"
       className="h-min w-min rounded bg-accent px-2"
-      asForeground
     >
       {children}
     </Text>

--- a/packages/react/stories/templates/Code.tsx
+++ b/packages/react/stories/templates/Code.tsx
@@ -8,6 +8,7 @@ export default function Code({ children }: TextProps) {
       align="right"
       variant="accent"
       className="h-min w-min rounded bg-accent px-2"
+      asForeground
     >
       {children}
     </Text>

--- a/packages/react/tests/Heading.test.tsx
+++ b/packages/react/tests/Heading.test.tsx
@@ -70,24 +70,57 @@ describe("Heading", () => {
     }
   });
 
-  it("applies the correct variant classes", () => {
-    for (const variant of TYPOGRAPHY_VARIANTS) {
-      render(<Heading variant={variant as TypographyVariant}>Variant {variant}</Heading>);
-      const element = screen.getByText(`Variant ${variant}`);
+  describe("variant", () => {
+    it("applies the correct variant classes", () => {
+      for (const variant of TYPOGRAPHY_VARIANTS) {
+        render(<Heading variant={variant as TypographyVariant}>Variant {variant}</Heading>);
+        const element = screen.getByText(`Variant ${variant}`);
 
-      let expectedCssClass = "";
-      if (variant === "default") {
-        expectedCssClass = "text-foreground";
-      } else if (variant === "inherit") {
-        expectedCssClass = "text-inherit";
-      } else {
-        expectedCssClass = `text-${variant}-foreground`;
+        let expectedCssClass = "";
+        if (variant === "default") {
+          expectedCssClass = "text-foreground";
+        } else if (variant === "inherit") {
+          expectedCssClass = "text-inherit";
+        } else if (
+          variant === "primary" ||
+          variant === "secondary" ||
+          variant === "muted" ||
+          variant === "accent"
+        ) {
+          expectedCssClass = `text-${variant}-foreground`;
+        } else {
+          expectedCssClass = `text-${variant}`;
+        }
+
+        expect(element.className).toBe(
+          `text-3xl font-bold ${expectedCssClass} font-display scroll-m-20`,
+        );
       }
+    });
 
-      expect(element.className).toBe(
-        `text-3xl font-bold ${expectedCssClass} font-display scroll-m-20`,
-      );
-    }
+    it("applies the correct variant classes for foreground variants", () => {
+      for (const variant of TYPOGRAPHY_VARIANTS) {
+        render(
+          <Heading variant={variant as TypographyVariant} asForeground>
+            Variant {variant}
+          </Heading>,
+        );
+        const element = screen.getByText(`Variant ${variant}`);
+
+        let expectedCssClass = "";
+        if (variant === "default") {
+          expectedCssClass = "text-foreground";
+        } else if (variant === "inherit") {
+          expectedCssClass = "text-inherit";
+        } else {
+          expectedCssClass = `text-${variant}-foreground`;
+        }
+
+        expect(element.className).toBe(
+          `text-3xl font-bold ${expectedCssClass} font-display scroll-m-20`,
+        );
+      }
+    });
   });
 
   it("applies the correct text alignment classes", () => {

--- a/packages/react/tests/Text.test.tsx
+++ b/packages/react/tests/Text.test.tsx
@@ -55,22 +55,43 @@ describe("Text", () => {
     }
   });
 
-  it("applies the correct variant classes", () => {
-    for (const variant of TYPOGRAPHY_VARIANTS) {
-      render(<Text variant={variant}>Variant {variant}</Text>);
-      const element = screen.getByText(`Variant ${variant}`);
+  describe("variant", () => { 
+    it("applies the correct variant classes", () => {
+      for (const variant of TYPOGRAPHY_VARIANTS) {
+        render(<Text variant={variant}>Variant {variant}</Text>);
+        const element = screen.getByText(`Variant ${variant}`);
 
-      let expectedCssClass = "";
-      if (variant === "default") {
-        expectedCssClass = "text-foreground";
-      } else if (variant === "inherit") {
-        expectedCssClass = "text-inherit";
-      } else {
-        expectedCssClass = `text-${variant}-foreground`;
+        let expectedCssClass = "";
+        if (variant === "default") {
+          expectedCssClass = "text-foreground";
+        } else if (variant === "inherit") {
+          expectedCssClass = "text-inherit";
+        } else if (variant === "primary" || variant === "secondary" || variant === "muted" || variant === "accent") {
+          expectedCssClass = `text-${variant}-foreground`;
+        } else {
+          expectedCssClass = `text-${variant}`;
+        }
+
+        expect(element.className).toBe(`${expectedCssClass} font-display`);
       }
+    });
+    
+    describe("asForeground", () => {
+      it("applies the correct foreground class when asForeground is true", () => {
+        render(<Text asForeground>Sample text</Text>);
+        expect(screen.getByText("Sample text").className).toBe("text-foreground font-display");
+      });
 
-      expect(element.className).toBe(`${expectedCssClass} font-display`);
-    }
+      it("with accent color, does not apply the foreground class when asForeground is false", () => {
+        render(<Text variant="info" asForeground={false}>Sample text</Text>);
+        expect(screen.getByText("Sample text").className).toBe("text-info font-display");
+      });
+
+      it("with accent color, applies the foreground class when asForeground is false", () => {
+        render(<Text variant="info" asForeground>Sample text</Text>);
+        expect(screen.getByText("Sample text").className).toBe("text-info-foreground font-display");
+      });
+    });
   });
 
   it("applies the correct text alignment classes", () => {

--- a/packages/react/tests/Text.test.tsx
+++ b/packages/react/tests/Text.test.tsx
@@ -55,7 +55,7 @@ describe("Text", () => {
     }
   });
 
-  describe("variant", () => { 
+  describe("variant", () => {
     it("applies the correct variant classes", () => {
       for (const variant of TYPOGRAPHY_VARIANTS) {
         render(<Text variant={variant}>Variant {variant}</Text>);
@@ -66,7 +66,12 @@ describe("Text", () => {
           expectedCssClass = "text-foreground";
         } else if (variant === "inherit") {
           expectedCssClass = "text-inherit";
-        } else if (variant === "primary" || variant === "secondary" || variant === "muted" || variant === "accent") {
+        } else if (
+          variant === "primary" ||
+          variant === "secondary" ||
+          variant === "muted" ||
+          variant === "accent"
+        ) {
           expectedCssClass = `text-${variant}-foreground`;
         } else {
           expectedCssClass = `text-${variant}`;
@@ -75,22 +80,27 @@ describe("Text", () => {
         expect(element.className).toBe(`${expectedCssClass} font-display`);
       }
     });
-    
-    describe("asForeground", () => {
-      it("applies the correct foreground class when asForeground is true", () => {
-        render(<Text asForeground>Sample text</Text>);
-        expect(screen.getByText("Sample text").className).toBe("text-foreground font-display");
-      });
 
-      it("with accent color, does not apply the foreground class when asForeground is false", () => {
-        render(<Text variant="info" asForeground={false}>Sample text</Text>);
-        expect(screen.getByText("Sample text").className).toBe("text-info font-display");
-      });
+    it("applies the correct variant classes for foreground variants", () => {
+      for (const variant of TYPOGRAPHY_VARIANTS) {
+        render(
+          <Text variant={variant} asForeground>
+            Variant {variant}
+          </Text>,
+        );
+        const element = screen.getByText(`Variant ${variant}`);
 
-      it("with accent color, applies the foreground class when asForeground is false", () => {
-        render(<Text variant="info" asForeground>Sample text</Text>);
-        expect(screen.getByText("Sample text").className).toBe("text-info-foreground font-display");
-      });
+        let expectedCssClass = "";
+        if (variant === "default") {
+          expectedCssClass = "text-foreground";
+        } else if (variant === "inherit") {
+          expectedCssClass = "text-inherit";
+        } else {
+          expectedCssClass = `text-${variant}-foreground`;
+        }
+
+        expect(element.className).toBe(`${expectedCssClass} font-display`);
+      }
     });
   });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated the roadmap with a note outlining future considerations for the accent feature.
- **New Features**
	- Introduced a new toggle option in heading and text components that lets you switch between standard and lighter foreground color styles.
	- Added interactive demo entries to showcase the impact of the new foreground styling option.
- **Tests**
	- Enhanced test coverage for the heading and text components to include checks for the new foreground styling option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->