### PR TITLE
ci: Don't run Chromatic during Renovate-sourced PRs

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,22 +1,17 @@
 name: "Chromatic"
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "packages/**/CHANGELOG.md" # with a pending release
   pull_request:
     branches:
       - main
-    branches-ignore:
-      - "renovate/**"
   workflow_dispatch:
 
 jobs:
   chromatic-primitives:
     runs-on: ubuntu-latest
     timeout-minutes: 4
+    # Exclude Renovate PRs
+    if: ${{ !startsWith(github.head_ref, 'renovate/') }}
 
     defaults:
       run:
@@ -48,6 +43,8 @@ jobs:
   chromatic-forms:
     runs-on: ubuntu-latest
     timeout-minutes: 4
+    # Exclude Renovate PRs
+    if: ${{ !startsWith(github.head_ref, 'renovate/') }}
 
     defaults:
       run:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -4,14 +4,35 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - "packages/**"
   workflow_dispatch:
 
 jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      packages: ${{ steps.filter.outputs.changes }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Detect file changes
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            primitives:
+              - 'packages/primitives/**'
+            forms:
+              - 'packages/forms/**'
+
   chromatic-primitives:
+    needs: detect-changes
     runs-on: ubuntu-latest
     timeout-minutes: 4
     # Exclude Renovate PRs
-    if: ${{ !startsWith(github.head_ref, 'renovate/') }}
+    if: ${{ needs.detect-changes.outputs.packages != '[]' && !startsWith(github.head_ref, 'renovate/') }}
 
     defaults:
       run:
@@ -41,10 +62,11 @@ jobs:
           buildScriptName: "storybook:build"
 
   chromatic-forms:
+    needs: detect-changes
     runs-on: ubuntu-latest
     timeout-minutes: 4
     # Exclude Renovate PRs
-    if: ${{ !startsWith(github.head_ref, 'renovate/') }}
+    if: ${{ needs.detect-changes.outputs.packages != '[]' && !startsWith(github.head_ref, 'renovate/') }}
 
     defaults:
       run:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,6 +1,17 @@
 name: "Chromatic"
 
-on: push
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "packages/**/CHANGELOG.md" # with a pending release
+  pull_request:
+    branches:
+      - main
+    branches-ignore:
+      - "renovate/**"
+  workflow_dispatch:
 
 jobs:
   chromatic-primitives:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated workflow to run Chromatic checks only on pull requests to the main branch or when manually triggered.
  - Chromatic checks will now be skipped for branches starting with "renovate/".
  - Optimized workflow to run visual testing jobs only when relevant package changes are detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->